### PR TITLE
Issue 8/ps3 refinement

### DIFF
--- a/src/bias_2015/pathogenic_classifiers.py
+++ b/src/bias_2015/pathogenic_classifiers.py
@@ -137,23 +137,18 @@ def get_ps3(variant, gloc_to_pubmed_id_list):
     ps3 = ""
     start_pos = int(variant.position)
     end_pos = start_pos + len(variant.refAllele)
-    all_pubmed_ids = set()
-    for x in range(start_pos, end_pos):
-        gloc = (variant.chromosome, x)
-        if gloc_to_pubmed_id_list.get(gloc):
-            for pubmed_id in gloc_to_pubmed_id_list[gloc]:
-                all_pubmed_ids.add(pubmed_id)
-
+    gloc = (variant.chromosome, str(start_pos), str(end_pos))
+    all_pubmed_ids = gloc_to_pubmed_id_list.get(gloc, "")
     total_pubmed_count = len(all_pubmed_ids)
     sorted_pubmed_ids = sorted(list(all_pubmed_ids))
-    if total_pubmed_count > 1:
+    if total_pubmed_count > 3: # NOTE: This ensures the variant is called pathogenic! 
         score = 2
         pubmed_str = ', '.join(sorted_pubmed_ids)
-        ps3 = f"PS3 ({score}) - Variants pathogenicity is supported by multiple pubmed studies {pubmed_str} as established by AVADA"
+        ps3 = f"PS3 ({score}): Variants pathogenicity is supported by multiple pubmed studies {pubmed_str} as established by AVADA"
     elif total_pubmed_count > 0:
         score = 1
         pubmed = sorted_pubmed_ids[0]
-        ps3 = f"PS3 ({score}) - Variants pathogenicity is supported by pubmed study {pubmed} as established by AVADA"
+        ps3 = f"PS3 ({score}): Variants pathogenicity is supported by pubmed study {pubmed} as established by AVADA"
     return score, ps3
 
 

--- a/src/bias_2015/variant_interpretation_dataset_loader.py
+++ b/src/bias_2015/variant_interpretation_dataset_loader.py
@@ -163,13 +163,12 @@ def get_gloc_to_pubmed_id_list(literature_supported_variants_fp):
             start = split_line[1]
             stop = split_line[2]
             pubmed_id = split_line[3]
-            for x in range(int(start), int(stop)):
-                pos = (chrom, x)
-                if gloc_to_pubmed_id_list.get(pos):
-                    if pubmed_id not in gloc_to_pubmed_id_list[pos]: 
-                        gloc_to_pubmed_id_list[pos].append(pubmed_id)
-                else:
-                    gloc_to_pubmed_id_list[pos] = [pubmed_id]
+            pos = (chrom, start, stop) 
+            if gloc_to_pubmed_id_list.get(pos):
+                if pubmed_id not in gloc_to_pubmed_id_list[pos]: 
+                    gloc_to_pubmed_id_list[pos].append(pubmed_id)
+            else:
+                gloc_to_pubmed_id_list[pos] = [pubmed_id]
     if not gloc_to_pubmed_id_list:
         print(f"File {literature_supported_variants_fp} does not have any valid entries!")
     return gloc_to_pubmed_id_list

--- a/test/bias-2015/test_pathogenic_classifiers.py
+++ b/test/bias-2015/test_pathogenic_classifiers.py
@@ -161,14 +161,14 @@ def test_get_ps3_single_pubmed():
 
     # Set up the test data
     gloc_to_pubmed_id_list = {
-        ("chr1", 1014142): ["25307056"],
-        ("chr1", 1014143): ["25307056"]
+        ("chr1", '1014142', '1014143'): ["25307056"],
+        ("chr1", '1014143', '1014145'): ["25307056"]
     }
 
     # Perform the test
     score, ps3 = pathogenic_classifiers.get_ps3(variant, gloc_to_pubmed_id_list)
     expected_score = 1
-    expected_ps3 = "PS3 (1) - Variants pathogenicity is supported by pubmed study 25307056 as established by AVADA"
+    expected_ps3 = "PS3 (1): Variants pathogenicity is supported by pubmed study 25307056 as established by AVADA"
     assert (score, ps3) == (expected_score, expected_ps3)
 
 
@@ -181,14 +181,14 @@ def test_get_ps3_multiple_pubmeds():
 
     # Set up the test data
     gloc_to_pubmed_id_list = {
-        ("chr1", 1014142): ["25307056", "22859821"],
-        ("chr1", 1014143): ["25307056"]
+        ("chr1", '1014142', '1014143'): ["25307056", "22859821", "1111", "124"],
+        ("chr1", '1014143', '1014145'): ["25307056"]
     }
 
     # Perform the test
     score, ps3 = pathogenic_classifiers.get_ps3(variant, gloc_to_pubmed_id_list)
     expected_score = 2
-    expected_ps3 = "PS3 (2) - Variants pathogenicity is supported by multiple pubmed studies 22859821, 25307056 as established by AVADA"
+    expected_ps3 = "PS3 (2): Variants pathogenicity is supported by multiple pubmed studies 1111, 124, 22859821, 25307056 as established by AVADA"
     assert (score, ps3) == (expected_score, expected_ps3)
 
 def test_get_ps4():

--- a/test/bias-2015/test_variant_interpretation_dataset_loader.py
+++ b/test/bias-2015/test_variant_interpretation_dataset_loader.py
@@ -144,7 +144,7 @@ def test_get_gloc_to_pubmed_id_list():
     """
     test_data = "chr1\t1014142\t1014143\t25307056\n" + \
                 "chr1\t1014142\t1014143\t25307056\n" + \
-                "chr1\t1014313\t1014314\t22859821"
+                "chr1\t1014313\t1014315\t22859821"
 
     # Create a temporary file
     with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.txt') as tmp_file:
@@ -155,8 +155,8 @@ def test_get_gloc_to_pubmed_id_list():
         # Perform the test
         gloc_to_pubmed_id_list = vidl.get_gloc_to_pubmed_id_list(literature_supported_variants_fp)
         expected_output = {
-            ("chr1", 1014142): ["25307056"],
-            ("chr1", 1014313): ["22859821"]
+            ("chr1", '1014142', '1014143'): ["25307056"],
+            ("chr1", '1014313', '1014315'): ["22859821"]
         }
         assert gloc_to_pubmed_id_list == expected_output
     finally:
@@ -205,7 +205,8 @@ def test_get_dbsnpids_to_or():
         # Perform the test
         dbsnpid_to_data = vidl.get_dbsnpids_to_or(gwas_dbsnp_fp)
         expected_output = {
-            'chr1': {768252: (7.0, 0.0, 0.0, '35023831', 'GWAS and ExWAS of blood Mitochondrial DNA copy number identifies 71 loci and highlights a potential causal role in dementia.'
+            'chr1': {768252: (7.0, 0.0, 0.0, '35023831',
+                              'GWAS and ExWAS of blood Mitochondrial DNA copy number identifies 71 loci and highlights a potential causal role in dementia.'
                               , 3e-21, 'rs2977608')}
                            }
 


### PR DESCRIPTION
Change the inclusion criteria for a variant to be considered an AVADA variant. Previously if any position of the variant overlapped with an AVADA coordinate it was associated. This caused incorrect flagging when the AVADA variant was a large deletion and there were benign SNP's inside those deletion regions. 

To correct the inclusion criteria was updated such that the variant must have the same start/end position as the AVADA variant.  This could be done in a more refined way still by normalizing the amino acid change in AVADA, then ensuring the variant's aa change matches.