### PR TITLE
change imports in key modules to be relative instead of absolute

### DIFF
--- a/src/bias_2015/benign_classifiers.py
+++ b/src/bias_2015/benign_classifiers.py
@@ -1,7 +1,7 @@
 """
 BIAS-2015 implementation of the ACMG 2015 germline benign classifiers
 """
-from src.bias_2015.constants import clinvar_review_status_to_level, score_to_hum_readable, loeuf_thresholds, benign_thresholds
+from .constants import clinvar_review_status_to_level, score_to_hum_readable, loeuf_thresholds, benign_thresholds
 
 def get_ba1(variant):
     """

--- a/src/bias_2015/bias_variant_classification.py
+++ b/src/bias_2015/bias_variant_classification.py
@@ -2,8 +2,8 @@
 Implementing the guidelines set forth in https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4544753/
 ACMG/AMG 2015 interpretation guidelines. For each variant as many factors will be used as possible.
 '''
-from src.bias_2015 import benign_classifiers, pathogenic_classifiers
-from src.bias_2015.constants import high_uncertain_threshold, low_uncertain_threshold 
+from . import benign_classifiers, pathogenic_classifiers
+from .constants import high_uncertain_threshold, low_uncertain_threshold 
 
 def calc_pathogenic(pa, pvs, ps, pm, pp):
     """

--- a/src/bias_2015/pathogenic_classifiers.py
+++ b/src/bias_2015/pathogenic_classifiers.py
@@ -1,7 +1,7 @@
 """
 BIAS-2015 implementation of the ACMG 2015 germline pathogenic classifiers
 """
-from src.bias_2015.constants import clinvar_review_status_to_level, score_to_hum_readable, loeuf_thresholds, pathogenic_thresholds
+from .constants import clinvar_review_status_to_level, score_to_hum_readable, loeuf_thresholds, pathogenic_thresholds
 
 def get_pvs(variant, gene_name_to_3prime_region, chrom_to_pos_to_alt_to_splice_score, skip_list):
     """

--- a/src/bias_2015/variant_interpretation.py
+++ b/src/bias_2015/variant_interpretation.py
@@ -3,7 +3,7 @@ Implementing the guidelines set forth in https://www.ncbi.nlm.nih.gov/pmc/articl
 ACMG/AMG 2015 interpretation guidelines. For each variant as many factors will be used as possible.
 '''
 
-from src.bias_2015 import benign_classifiers, pathogenic_classifiers
+from . import benign_classifiers, pathogenic_classifiers
 
 def calc_pathogenic(pvs, ps, pm, pp):
     """


### PR DESCRIPTION
Very few changes here, just changing names like "src.bias_2015" in imports to be simply "." etc. Can confirm this is all that's needed to make module imports work above top-level.